### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server that provides an interface for interacting with Burpsuite Professional's scanning and proxy functionality.
 
+<a href="https://glama.ai/mcp/servers/@Cyreslab-AI/burpsuite-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Cyreslab-AI/burpsuite-mcp-server/badge" alt="Burpsuite Server MCP server" />
+</a>
+
 ## Overview
 
 This MCP server allows AI assistants to interact with Burpsuite Professional for web security testing and vulnerability scanning. It provides tools for:


### PR DESCRIPTION
This PR adds a badge for the [Burpsuite MCP Server](https://glama.ai/mcp/servers/@Cyreslab-AI/burpsuite-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@Cyreslab-AI/burpsuite-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Cyreslab-AI/burpsuite-mcp-server/badge" alt="Burpsuite Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.